### PR TITLE
fixed_constructor_for_group_entity

### DIFF
--- a/src/main/java/com/kodilla/ecommercee/group/domain/Group.java
+++ b/src/main/java/com/kodilla/ecommercee/group/domain/Group.java
@@ -3,6 +3,7 @@ package com.kodilla.ecommercee.group.domain;
 import com.kodilla.ecommercee.product.domain.Product;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -11,6 +12,7 @@ import java.util.List;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 @Entity
 @Table(name = "PRODUCT_GROUPS")
 public class Group {


### PR DESCRIPTION
Testy Postmanem nie przechodziły, bo Hibernate nie miał adnotacji @NoArgsConstructor dla encji Group. Był to na tyle mały problem, że nie chciałem zawracać dupy autorowi kontrolera, tylko naprawiłem to sam. Po dodaniu adnotacji testy przechodzą, kontroler działa poprawnie.