### PR TITLE
Build-fix

### DIFF
--- a/src/main/java/com/kodilla/ecommercee/product/repository/ProductDao.java
+++ b/src/main/java/com/kodilla/ecommercee/product/repository/ProductDao.java
@@ -13,6 +13,4 @@ public interface ProductDao extends CrudRepository<Product, Long> {
     @Override
     List<Product> findAll();
     List<Product> findAllById(List<Long> id);
-    @Override
-    List<Product> findAll();
 }


### PR DESCRIPTION
W ProductDao ta sama metoda była nadpisana dwukrotnie ( prawdopodobnie źle rozwiązany konflikt ) przez co nie przechodził build i testy.