### PR TITLE
createOrder endpoint fix

### DIFF
--- a/src/main/java/com/kodilla/ecommercee/order/domain/Order.java
+++ b/src/main/java/com/kodilla/ecommercee/order/domain/Order.java
@@ -45,7 +45,7 @@ public class Order {
     private LocalDate dateOfOrder;
 
     @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "USER_ID")
+    @JoinColumn(name = "USER")
     private User user;
 
     @ManyToMany


### PR DESCRIPTION
Endpoint createOrder z OrderControllera nie chciał działać i dawał błąd     SQLException Field 'user' doesn't a have default value
Okazało się, że Hibernete nie pasowała nazwa pola USER_ID w encji Order. Po drobnej zmianie na "USER" wszystko działa, kontroler śmiga, testy przechodzą.