### PR TITLE
set User's cartId field when creating cart

### DIFF
--- a/src/main/java/com/kodilla/ecommercee/cart/controller/CartController.java
+++ b/src/main/java/com/kodilla/ecommercee/cart/controller/CartController.java
@@ -5,12 +5,13 @@ import com.kodilla.ecommercee.cart.domain.CartDto;
 import com.kodilla.ecommercee.cart.mapper.CartMapper;
 import com.kodilla.ecommercee.cart.service.CartDbService;
 import com.kodilla.ecommercee.order.domain.Order;
+import com.kodilla.ecommercee.order.domain.OrderDto;
 import com.kodilla.ecommercee.product.domain.Product;
 import com.kodilla.ecommercee.product.domain.ProductDto;
-import com.kodilla.ecommercee.order.domain.OrderDto;
 import com.kodilla.ecommercee.product.mapper.ProductMapper;
 import lombok.Data;
 import org.springframework.web.bind.annotation.*;
+
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/kodilla/ecommercee/cart/domain/Cart.java
+++ b/src/main/java/com/kodilla/ecommercee/cart/domain/Cart.java
@@ -3,7 +3,6 @@ package com.kodilla.ecommercee.cart.domain;
 import com.kodilla.ecommercee.product.domain.Product;
 import com.kodilla.ecommercee.user.domain.User;
 import com.sun.istack.NotNull;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -49,7 +48,7 @@ public class Cart {
     @Column(name = "PRICE")
     private BigDecimal price;
 
-    @OneToOne(fetch = FetchType.EAGER)
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     @JoinColumn(name = "USER_ID")
     private User user;
 
@@ -60,6 +59,4 @@ public class Cart {
             inverseJoinColumns = {@JoinColumn(name = "PRODUCT_ID", referencedColumnName = "ID")}
     )
     private List<Product> products = new ArrayList<>();
-
-
 }

--- a/src/main/java/com/kodilla/ecommercee/cart/service/CartDbService.java
+++ b/src/main/java/com/kodilla/ecommercee/cart/service/CartDbService.java
@@ -6,6 +6,8 @@ import com.kodilla.ecommercee.order.domain.Order;
 import com.kodilla.ecommercee.order.repository.OrderDao;
 import com.kodilla.ecommercee.product.domain.Product;
 import com.kodilla.ecommercee.product.repository.ProductDao;
+import com.kodilla.ecommercee.user.domain.User;
+import com.kodilla.ecommercee.user.repository.UserDao;
 import lombok.Data;
 import org.springframework.stereotype.Service;
 
@@ -20,13 +22,18 @@ public class CartDbService {
     private final CartDao cartDao;
     private final ProductDao productDao;
     private final OrderDao orderDao;
+    private final UserDao userDao;
 
     public Optional<Cart> getCart(Long cartId){
         return cartDao.findById(cartId);
     }
 
     public Cart createCart(Cart cart){
-        return cartDao.save(cart);
+        Cart created = cartDao.save(cart);
+        User user = created.getUser();
+        user.setCart(created);
+        userDao.save(user);
+        return created;
     }
 
     public void addProducts(List<Long> productsIds, Cart cart) {

--- a/src/test/java/com/kodilla/ecommercee/cart/CartTestSuite.java
+++ b/src/test/java/com/kodilla/ecommercee/cart/CartTestSuite.java
@@ -49,7 +49,6 @@ public class CartTestSuite {
         Assert.assertTrue(savedCart.isPresent());
 
         //Clean up
-        cartDao.deleteById(cart.getId());
         userDao.deleteById(user.getId());
         productDao.deleteById(product.getId());
     }
@@ -76,7 +75,6 @@ public class CartTestSuite {
         Assert.assertEquals("kurtka", productName);
 
         //Clean up
-        cartDao.deleteById(cart.getId());
         userDao.deleteById(user.getId());
         productDao.deleteById(product.getId());
     }
@@ -104,7 +102,6 @@ public class CartTestSuite {
         Assert.assertEquals("Pawel", savedCart.getUser().getUsername());
 
         //Clean up
-        cartDao.deleteById(cart.getId());
         userDao.deleteById(user.getId());
         productDao.deleteById(product.getId());
     }
@@ -135,7 +132,6 @@ public class CartTestSuite {
         Assert.assertEquals("changedCart", changedCart.getName());
 
         //Clean up
-        cartDao.deleteById(cart.getId());
         userDao.deleteById(user.getId());
         productDao.deleteById(product.getId());
     }
@@ -149,6 +145,7 @@ public class CartTestSuite {
         cart.getProducts().add(product);
         product.getCarts().add(cart);
         user.setUsername("Pawel");
+        user.setCart(cart);
         userDao.save(user);
         productDao.save(product);
         cartDao.save(cart);
@@ -157,25 +154,14 @@ public class CartTestSuite {
         long productId = product.getId();
 
         //When
-        Optional<Cart> optionalCart = cartDao.findById(cartId);
-        Cart savedCart = optionalCart.orElseThrow(() -> new RuntimeException("No Cart"));
-        long savedCartId = savedCart.getId();
-        cartDao.deleteById(savedCartId);
-
-        Optional<User> optionalUser = userDao.findById(userId);
-        User savedUser = optionalUser.orElseThrow(() -> new RuntimeException("No User"));
-        Optional<Product> optionalProduct = productDao.findById(productId);
-        Product savedProduct = optionalProduct.orElseThrow(() -> new RuntimeException("No Product"));
-
+        userDao.deleteById(userId);
+        
         //Then
-        Assert.assertFalse(cartDao.findById(savedCartId).isPresent());
         Assert.assertTrue(productDao.findById(productId).isPresent());
-        Assert.assertTrue(userDao.findById(userId).isPresent());
-        Assert.assertEquals("kurtka", savedProduct.getName());
-        Assert.assertEquals("Pawel", savedUser.getUsername());
+        Assert.assertFalse(cartDao.findById(cartId).isPresent());
+        Assert.assertFalse(userDao.findById(userId).isPresent());
 
         //Clean up
-        userDao.deleteById(user.getId());
         productDao.deleteById(product.getId());
     }
 }


### PR DESCRIPTION
Utworzenie carta ustawia teraz pole cartId u Usera.
po utworzeniu carta pole cartId u usera pozostawało null, przez co usunięcie usera nie usuwało carta przez wiązanie, a to jedyny sposób (nie ma endpointu delete cart).

edit: ups, wywala błędy na testach. ale działa tak jak powinno na postmanie :P jutro się tym zajme już
edit2: ok poprawiłem testy. nie trzeba teraz sprzątać osobno carta, bo usunięcie usera usuwa już go.

